### PR TITLE
Prevent undefined response throwing errors during Array.prototype.slice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ function getRepoCommits (repoData, branch) {
     }, function(err, status, body, headers) {
       if (err) { reject(err); }
 
-      var commits = Array.prototype.slice.call(body);
+      var commits = Array.prototype.slice.call(body || []);
 
       resolve(commits);
     });


### PR DESCRIPTION
Hey @Schinkentanz, thanks for putting Daily Git together.

On my first pass, I got this error:

```
/Users/tannerhodges/.nvm/versions/node/v6.10.3/lib/node_modules/daily-git/src/index.js:95
      var commits = Array.prototype.slice.call(body);
                                          ^

TypeError: Array.prototype.slice called on null or undefined
```

Some of my repos return empty responses (assuming that's because I either haven't committed anything recently, or because I triggered GitHub's rate limit).

To fix, I added an empty array fallback for cases where `body` is undefined.